### PR TITLE
Added Buff Craft Value and Craft % Value

### DIFF
--- a/no-api-version/content.js
+++ b/no-api-version/content.js
@@ -94,8 +94,9 @@ function findInContainer(container, className) {
 
 async function getItemStickerPrice(container) {
   let totalStickerPrice = 0;
-
-  const stickerContainer = findInContainer(container, 'sticker-container');
+  const itemContainer = findInContainer(container, 'item-grid');
+  const stickerContainer = findInContainer(itemContainer, 'sticker-container');
+  if (!stickerContainer) return null;
 
   const stickerRefs = [...stickerContainer.getElementsByTagName('img')].map(img =>
     img.getAttribute('aria-describedby')
@@ -104,7 +105,6 @@ async function getItemStickerPrice(container) {
   for (let i = 0; i < stickerRefs.length; i++) {
     const stickerRef = stickerRefs[i];
     const stickerText = document.querySelector(`#${stickerRef}`).innerHTML;
-
     if(!stickerText.includes('0%')) continue;
 
     const sticker = stickerText.match(/^.*(?=\s\d+%)/)
@@ -135,6 +135,7 @@ async function copyAndPasteItemName() {
 
   const price = await getBuffPrice(name);
   const stickerPrice = await getItemStickerPrice(cdkOverlayContainer)
+  console.log(stickerPrice)
 
   if (!ngStarInsertedDiv) return null;
 
@@ -173,27 +174,26 @@ async function copyAndPasteItemName() {
       newPriceDiv.style.color = 'red';
       newPriceDiv.textContent = `$${price} (${discount}%)`;
     }
-
-    const priceWithStickers = price + stickerPrice //cost to 4x craft on buff
-    const differenceWithStickers = priceWithStickers - actualPriceNumber  
+    if(stickerPrice) {
+    const priceWithStickers = price + stickerPrice
     const differenceStickersPercentage = (actualPriceNumber / priceWithStickers) * 100;
     const discountSticker = Math.round(differenceStickersPercentage);
 
-    if (isNaN(discountSticker)) {
-      newStickerDiv.style.color = 'orange';
-      newStickerDiv.textContent = `${discountSticker}%`;
-    }
-    else if (discountSticker < 50 && discountSticker > 0) {
-      newStickerDiv.style.color = 'green';
-      newStickerDiv.textContent = `${discountSticker}% SV ($${priceWithStickers.toFixed(2)} CV)`;
-    } else {
-      newStickerDiv.style.color = 'red';
-      newStickerDiv.textContent = `${discountSticker}% SV ($${priceWithStickers.toFixed(2)} CV)`;
+      if (discountSticker < 50 && discountSticker >= 0 || isNaN(discountSticker)) {
+        newStickerDiv.style.color = 'green';
+        newStickerDiv.textContent = `${discountSticker}% SV ($${priceWithStickers.toFixed(2)} CV)`;
+      }   else {
+        newStickerDiv.style.color = 'red';
+        newStickerDiv.textContent = `${discountSticker}% SV ($${priceWithStickers.toFixed(2)} CV)`;
+      }
     }
   }
 
   parentDiv.appendChild(newPriceDiv);
-  parentDiv.appendChild(newStickerDiv);
+
+  if(stickerPrice){
+    parentDiv.appendChild(newStickerDiv);
+  }
 
 
   // Create a link icon with a href

--- a/no-api-version/content.js
+++ b/no-api-version/content.js
@@ -168,28 +168,6 @@ async function copyAndPasteItemName() {
     const discount = Math.round(differencePercentage);
 
     if (isNaN(discount)) {
-<<<<<<< Updated upstream
-      newPriceDiv.style.color = 'orange';
-      newPriceDiv.textContent = `$${price}`;
-    }
-    else if (actualPriceNumber < price) {
-      newPriceDiv.style.color = 'green';
-      newPriceDiv.textContent = `$${price} (+${discount}%)`;
-    } else {
-      newPriceDiv.style.color = 'red';
-      newPriceDiv.textContent = `$${price} (${discount}%)`;
-    }
-    if(stickerPrice) {
-    const priceWithStickers = price + stickerPrice
-    const differenceStickersPercentage = (actualPriceNumber / priceWithStickers) * 100;
-    const discountSticker = Math.round(differenceStickersPercentage);
-
-      if (discountSticker < 50 && discountSticker >= 0 || isNaN(discountSticker)) {
-        newStickerDiv.style.color = 'green';
-        newStickerDiv.textContent = `${discountSticker}% SV ($${priceWithStickers.toFixed(2)} CV)`;
-      }   else {
-        newStickerDiv.style.color = 'red';
-=======
       newPriceDiv.style.color = settings.neutralColor;
       newPriceDiv.textContent = `$${price}`;
     }
@@ -210,7 +188,6 @@ async function copyAndPasteItemName() {
         newStickerDiv.textContent = `${discountSticker}% SV ($${priceWithStickers.toFixed(2)} CV)`;
       }  else {
         newStickerDiv.style.color = settings.lossColor;
->>>>>>> Stashed changes
         newStickerDiv.textContent = `${discountSticker}% SV ($${priceWithStickers.toFixed(2)} CV)`;
       }
     }
@@ -240,9 +217,6 @@ setInterval(() => {
   if (cdkOverlayContainer && cdkOverlayContainer.children.length > 0 && !cdkOverlayContainer.querySelector('#buff-price')) {
     copyAndPasteItemName();
   }
-<<<<<<< Updated upstream
-}, 1000);
-=======
 }, 1000);
 
 chrome.runtime.sendMessage({ action: 'getSettings' }, async function (response) {
@@ -255,4 +229,3 @@ chrome.runtime.sendMessage({ action: 'getSettings' }, async function (response) 
     neutralColor: response.neutralColor || '#FFA500',
   }
 });
->>>>>>> Stashed changes

--- a/no-api-version/content.js
+++ b/no-api-version/content.js
@@ -1,3 +1,5 @@
+let settings = undefined;
+
 function parseItem(name, details) {
 
   const item = {
@@ -182,7 +184,7 @@ async function copyAndPasteItemName() {
       const priceWithStickers = price + stickerPrice
       const differenceStickersPercentage = (actualPriceNumber / priceWithStickers) * 100;
       const discountSticker = Math.round(differenceStickersPercentage);
-      console.log(settings.stickerValueThreshold);
+
       if (discountSticker < settings.stickerValueThreshold && discountSticker >= 0 || isNaN(discountSticker)) {
         newStickerDiv.style.color = settings.profitColor;
         newStickerDiv.textContent = `${discountSticker}% SV ($${priceWithStickers.toFixed(2)} CV)`;
@@ -219,11 +221,10 @@ setInterval(() => {
   }
 }, 1000);
 
-chrome.runtime.sendMessage({ action: 'getSettings' }, async function (response) {
-  console.log(response)
+chrome.runtime.sendMessage({ action: 'getSettings' }, function (response) {
   settings = {
-    enableStickers: response.enableStickers || true,
-    stickerValueThreshold: response.stickerValueThreshold ,
+    enableStickers: response.enableStickers || true, 
+    stickerValueThreshold: response.stickerValueThreshold || 50,
     profitColor: response.profitColor || '#00FF00',
     lossColor: response.lossColor || '#FF0000',
     neutralColor: response.neutralColor || '#FFA500',

--- a/no-api-version/content.js
+++ b/no-api-version/content.js
@@ -141,14 +141,19 @@ async function copyAndPasteItemName() {
   const parentDiv = document.createElement('div');
   parentDiv.style.display = 'flex';
   parentDiv.style.justifyContent = 'center';
+  parentDiv.style.gap = '10px';
 
-  const newDiv = document.createElement('div');
-  newDiv.style.fontSize = '20px';
-  newDiv.id = 'buff-price';
+  const newPriceDiv = document.createElement('div');
+  newPriceDiv.style.fontSize = '20px';
+  newPriceDiv.id = 'buff-price';
+
+  const newStickerDiv = document.createElement('div');
+  newStickerDiv.style.fontSize = '20px';
+  newStickerDiv.id = 'sticker-price';
 
   if (!price && price !== 0) {
-    newDiv.style.color = 'red';
-    newDiv.textContent = 'No price found';
+    newPriceDiv.style.color = 'red';
+    newPriceDiv.textContent = 'No price found';
   } else {
     const actualPrice = ngStarInsertedDiv.textContent.trim();
     const actualPriceNumber = parseFloat(actualPrice.replace('$', '').replace(',', ''));
@@ -158,19 +163,38 @@ async function copyAndPasteItemName() {
     const discount = Math.round(differencePercentage);
 
     if (isNaN(discount)) {
-      newDiv.style.color = 'orange';
-      newDiv.textContent = `$${price}`;
+      newPriceDiv.style.color = 'orange';
+      newPriceDiv.textContent = `$${price}`;
     }
     else if (actualPriceNumber < price) {
-      newDiv.style.color = 'green';
-      newDiv.textContent = `$${price} (+${discount}%)`;
+      newPriceDiv.style.color = 'green';
+      newPriceDiv.textContent = `$${price} (+${discount}%)`;
     } else {
-      newDiv.style.color = 'red';
-      newDiv.textContent = `$${price} (${discount}%)`;
+      newPriceDiv.style.color = 'red';
+      newPriceDiv.textContent = `$${price} (${discount}%)`;
+    }
+
+    const priceWithStickers = price + stickerPrice //cost to 4x craft on buff
+    const differenceWithStickers = priceWithStickers - actualPriceNumber  
+    const differenceStickersPercentage = (actualPriceNumber / priceWithStickers) * 100;
+    const discountSticker = Math.round(differenceStickersPercentage);
+
+    if (isNaN(discountSticker)) {
+      newStickerDiv.style.color = 'orange';
+      newStickerDiv.textContent = `${discountSticker}%`;
+    }
+    else if (discountSticker < 50 && discountSticker > 0) {
+      newStickerDiv.style.color = 'green';
+      newStickerDiv.textContent = `${discountSticker}% SV ($${priceWithStickers.toFixed(2)} CC)`;
+    } else {
+      newStickerDiv.style.color = 'red';
+      newStickerDiv.textContent = `${discountSticker}% SV ($${priceWithStickers.toFixed(2)} CC)`;
     }
   }
 
-  parentDiv.appendChild(newDiv);
+  parentDiv.appendChild(newPriceDiv);
+  parentDiv.appendChild(newStickerDiv);
+
 
   // Create a link icon with a href
   const link = document.createElement('a');

--- a/no-api-version/content.js
+++ b/no-api-version/content.js
@@ -94,10 +94,12 @@ function findInContainer(container, className) {
 
 async function getItemStickerPrice(container) {
   let totalStickerPrice = 0;
+
   const itemContainer = findInContainer(container, 'item-grid');
   const stickerContainer = findInContainer(itemContainer, 'sticker-container');
-  if (!stickerContainer) return null;
 
+  if (!stickerContainer || !settings.enableStickers) return null;
+  
   const stickerRefs = [...stickerContainer.getElementsByTagName('img')].map(img =>
     img.getAttribute('aria-describedby')
   );
@@ -135,18 +137,20 @@ async function copyAndPasteItemName() {
 
   const price = await getBuffPrice(name);
   const stickerPrice = await getItemStickerPrice(cdkOverlayContainer)
-  console.log(stickerPrice)
 
   if (!ngStarInsertedDiv) return null;
 
-  const parentDiv = document.createElement('div');
-  parentDiv.style.display = 'flex';
-  parentDiv.style.justifyContent = 'center';
-  parentDiv.style.gap = '10px';
+  const newPriceParentDiv = document.createElement('div');
+  newPriceParentDiv.style.display = 'flex';
+  newPriceParentDiv.style.justifyContent = 'center';
 
   const newPriceDiv = document.createElement('div');
   newPriceDiv.style.fontSize = '20px';
   newPriceDiv.id = 'buff-price';
+
+  const newStickerParentDiv = document.createElement('div');
+  newStickerParentDiv.style.display = 'flex';
+  newStickerParentDiv.style.justifyContent = 'center';
 
   const newStickerDiv = document.createElement('div');
   newStickerDiv.style.fontSize = '20px';
@@ -164,6 +168,7 @@ async function copyAndPasteItemName() {
     const discount = Math.round(differencePercentage);
 
     if (isNaN(discount)) {
+<<<<<<< Updated upstream
       newPriceDiv.style.color = 'orange';
       newPriceDiv.textContent = `$${price}`;
     }
@@ -184,17 +189,32 @@ async function copyAndPasteItemName() {
         newStickerDiv.textContent = `${discountSticker}% SV ($${priceWithStickers.toFixed(2)} CV)`;
       }   else {
         newStickerDiv.style.color = 'red';
+=======
+      newPriceDiv.style.color = settings.neutralColor;
+      newPriceDiv.textContent = `$${price}`;
+    }
+    else if (actualPriceNumber < price) {
+      newPriceDiv.style.color = settings.profitColor;
+      newPriceDiv.textContent = `$${price} (+${discount}%)`;
+    } else {
+      newPriceDiv.style.color = settings.lossColor;
+      newPriceDiv.textContent = `$${price} (${discount}%)`;
+    }
+    if(settings.enableStickers && stickerPrice) {
+      const priceWithStickers = price + stickerPrice
+      const differenceStickersPercentage = (actualPriceNumber / priceWithStickers) * 100;
+      const discountSticker = Math.round(differenceStickersPercentage);
+      console.log(settings.stickerValueThreshold);
+      if (discountSticker < settings.stickerValueThreshold && discountSticker >= 0 || isNaN(discountSticker)) {
+        newStickerDiv.style.color = settings.profitColor;
+        newStickerDiv.textContent = `${discountSticker}% SV ($${priceWithStickers.toFixed(2)} CV)`;
+      }  else {
+        newStickerDiv.style.color = settings.lossColor;
+>>>>>>> Stashed changes
         newStickerDiv.textContent = `${discountSticker}% SV ($${priceWithStickers.toFixed(2)} CV)`;
       }
     }
   }
-
-  parentDiv.appendChild(newPriceDiv);
-
-  if(stickerPrice){
-    parentDiv.appendChild(newStickerDiv);
-  }
-
 
   // Create a link icon with a href
   const link = document.createElement('a');
@@ -202,9 +222,16 @@ async function copyAndPasteItemName() {
   link.target = '_blank';
   link.innerHTML = '<mat-icon _ngcontent-ele-c200="" role="img" class="mat-icon notranslate material-icons mat-icon-no-color" aria-hidden="true" data-mat-icon-type="font">link</mat-icon>';
   link.style.marginLeft = '10px';
-  parentDiv.appendChild(link);
+  
 
-  ngStarInsertedDiv.parentNode.insertBefore(parentDiv, ngStarInsertedDiv.nextSibling);
+  newPriceParentDiv.appendChild(newPriceDiv);
+  newPriceParentDiv.appendChild(link);
+  if(settings.enableStickers){
+    newStickerParentDiv.appendChild(newStickerDiv);
+  }
+
+  ngStarInsertedDiv.parentNode.insertBefore(newPriceParentDiv, ngStarInsertedDiv.nextSibling);
+  newPriceParentDiv.parentNode.insertBefore(newStickerParentDiv, newPriceParentDiv.nextSibling);
 }
 
 setInterval(() => {
@@ -213,4 +240,19 @@ setInterval(() => {
   if (cdkOverlayContainer && cdkOverlayContainer.children.length > 0 && !cdkOverlayContainer.querySelector('#buff-price')) {
     copyAndPasteItemName();
   }
+<<<<<<< Updated upstream
 }, 1000);
+=======
+}, 1000);
+
+chrome.runtime.sendMessage({ action: 'getSettings' }, async function (response) {
+  console.log(response)
+  settings = {
+    enableStickers: response.enableStickers || true,
+    stickerValueThreshold: response.stickerValueThreshold ,
+    profitColor: response.profitColor || '#00FF00',
+    lossColor: response.lossColor || '#FF0000',
+    neutralColor: response.neutralColor || '#FFA500',
+  }
+});
+>>>>>>> Stashed changes

--- a/no-api-version/content.js
+++ b/no-api-version/content.js
@@ -185,10 +185,10 @@ async function copyAndPasteItemName() {
     }
     else if (discountSticker < 50 && discountSticker > 0) {
       newStickerDiv.style.color = 'green';
-      newStickerDiv.textContent = `${discountSticker}% SV ($${priceWithStickers.toFixed(2)} CC)`;
+      newStickerDiv.textContent = `${discountSticker}% SV ($${priceWithStickers.toFixed(2)} CV)`;
     } else {
       newStickerDiv.style.color = 'red';
-      newStickerDiv.textContent = `${discountSticker}% SV ($${priceWithStickers.toFixed(2)} CC)`;
+      newStickerDiv.textContent = `${discountSticker}% SV ($${priceWithStickers.toFixed(2)} CV)`;
     }
   }
 

--- a/no-api-version/options.html
+++ b/no-api-version/options.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<title>Extension Options</title>
+	<link rel="stylesheet" href="options.css">
+</head>
+
+<body>
+	<h1>Extension Options</h1>
+	<h3>No need to save anything, it'll be automatically saved in the extension localStorage. Refresh (F5) on CSFloat to see your changes</h3>
+	<label>
+		<input type="checkbox" id="enableStickers"> Enable Sticker(s) Price Checker:
+	</label>
+	<br>
+	<label>
+		<input type="number" id="stickerValueThreshold"> Profit Sticker % Threshold:
+	</label>
+	<br>
+	<br>
+	<label>
+		Profit color:
+		<input type="color" id="profitColor">
+	</label>
+	<br>
+	<label>
+		Loss color:
+		<input type="color" id="lossColor">
+	</label>
+	<br>
+	<label>
+		Neutral color:
+		<input type="color" id="neutralColor">
+	</label>
+	<br>
+	<br>
+	<button id="reset">Reset</button>
+	<script src="options.js"></script>
+</body>
+
+</html>

--- a/no-api-version/options.js
+++ b/no-api-version/options.js
@@ -1,0 +1,56 @@
+document.addEventListener('DOMContentLoaded', async function () {
+	const enableStickersOption = document.getElementById('enableStickers');
+	const stickerValueThresholdOption = document.getElementById('stickerValueThreshold');
+	const profitColorOption = document.getElementById('profitColor');
+	const lossColorOption = document.getElementById('lossColor');
+	const neutralColorOption = document.getElementById('neutralColor');
+	const resetButton = document.getElementById('reset');
+
+	await chrome.storage.local.get(['enableStickers', 'stickerValueThreshold', 'profitColor', 'lossColor', 'neutralColor'], function (result) {
+		enableStickersOption.checked = result.enableStickers || false;
+		stickerValueThresholdOption.value = result.stickerValueThreshold || 50;
+		profitColorOption.value = result.profitColor || '#00FF00';
+		lossColorOption.value = result.lossColor || '#FF0000';
+		neutralColorOption.value = result.neutralColor || '#FFA500';
+	});
+
+	enableStickersOption.addEventListener('change', function () {
+		const enableStickers = enableStickersOption.checked;
+		chrome.storage.local.set({ enableStickers });
+	});
+
+	neutralColorOption.addEventListener('change', function () {
+		const stickerValueThreshold = stickerValueThresholdOption.value;
+		chrome.storage.local.set({ stickerValueThreshold });
+	});
+
+	profitColorOption.addEventListener('change', function () {
+		const profitColor = profitColorOption.value;
+		chrome.storage.local.set({ profitColor });
+	});
+
+	lossColorOption.addEventListener('change', function () {
+		const lossColor = lossColorOption.value;
+		chrome.storage.local.set({ lossColor });
+	});
+
+	neutralColorOption.addEventListener('change', function () {
+		const neutralColor = neutralColorOption.value;
+		chrome.storage.local.set({ neutralColor });
+	});
+
+	resetButton.addEventListener('click', function () {
+		chrome.storage.local.set({
+			enableStickers: false,
+			stickerValueThreshold: 50,
+			profitColor: '#00FF00',
+			lossColor: '#FF0000',
+			neutralColor: '#FFA500'
+		});
+		enableStickersOption.checked = false;
+		stickerValueThresholdOption.value = 50
+		profitColorOption.value = '#00FF00';
+		lossColorOption.value = '#FF0000';
+		neutralColorOption.value = '#FFA500';
+	});
+});


### PR DESCRIPTION
Added feature to show the buff craft price sticker value % against the listed float sale price.

I normally think its base skin price + sticker prices. But some high tier traders might say skin prices doesn't matter depending on sticker value. If this is the case I can add it in another commit.

The price checker ignores scraped sticker values.

I was a bit lazy with the UI but me or you can update to your liking. Not sure on the value thresholds for color coding 

![image](https://github.com/bycop/csfloat-buff-checker/assets/142036562/8a3f6cc3-305f-49e5-a48e-7db5871f75ab)

![image](https://github.com/bycop/csfloat-buff-checker/assets/142036562/841a64f8-0dbc-463b-aff1-3be03fad774c)