### PR TITLE
Added Sticker % Value

### DIFF
--- a/no-api-version/background.js
+++ b/no-api-version/background.js
@@ -20,9 +20,10 @@ chrome.action.onClicked.addListener(function (tab) {
 
 chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
 	if (request.action === 'getSettings') {
-		chrome.storage.local.get(['enableStickers', 'profitColor', 'lossColor', 'neutralColor'], function (result) {
+		chrome.storage.local.get(['enableStickers', 'stickerThreshold', 'profitColor', 'lossColor', 'neutralColor'], function (result) {
 			const settings = {
-				enableStickers: result.enableStickers || true,
+				enableStickers: result.enableStickers || false,
+				stickerThreshold: response.stickerThreshold || 50,
 				profitColor: result.profitColor || '#00FF00',
 				lossColor: result.lossColor || '#FF0000',
 				neutralColor: result.neutralColor || '#FFA500'

--- a/no-api-version/content.js
+++ b/no-api-version/content.js
@@ -114,8 +114,9 @@ async function getItemStickerPrice(container) {
     const sticker = stickerText.match(/^.*(?=\s\d+%)/)
 
     const stickerPrice = await getBuffPrice(sticker);
-    if(stickerPrice.includes('N/A')) continue;
-    
+
+    if(typeof(stickerPrice) != "number") continue;
+
     totalStickerPrice += stickerPrice;
   }
 

--- a/no-api-version/content.js
+++ b/no-api-version/content.js
@@ -167,11 +167,11 @@ setInterval(() => {
   }
 }, 1000);
 
-chrome.runtime.sendMessage({ action: 'getSettings' }, function (response) {
+chrome.storage.local.get(['enableStickers', 'profitColor', 'lossColor', 'neutralColor'], function(response) {
   settings = {
-    enableStickers: response.enableStickers || true,
+    enableStickers: response.enableStickers || false,
     profitColor: response.profitColor || '#00FF00',
     lossColor: response.lossColor || '#FF0000',
     neutralColor: response.neutralColor || '#FFA500',
   }
-});
+});	  

--- a/no-api-version/content.js
+++ b/no-api-version/content.js
@@ -110,11 +110,12 @@ async function getItemStickerPrice(container) {
     const stickerRef = stickerRefs[i];
     const stickerText = document.querySelector(`#${stickerRef}`).innerHTML;
     if(!stickerText.includes('0%')) continue;
-
+    
     const sticker = stickerText.match(/^.*(?=\s\d+%)/)
 
     const stickerPrice = await getBuffPrice(sticker);
-
+    if(stickerPrice.includes('N/A')) continue;
+    
     totalStickerPrice += stickerPrice;
   }
 

--- a/no-api-version/content.js
+++ b/no-api-version/content.js
@@ -167,7 +167,7 @@ setInterval(() => {
   }
 }, 1000);
 
-chrome.storage.local.get(['enableStickers', 'profitColor', 'lossColor', 'neutralColor'], function(response) {
+chrome.storage.local.get(['enableStickers', 'profitColor', 'lossColor', 'neutralColor'], (response) => {
   settings = {
     enableStickers: response.enableStickers || false,
     profitColor: response.profitColor || '#00FF00',

--- a/no-api-version/content.js
+++ b/no-api-version/content.js
@@ -101,7 +101,7 @@ async function getItemStickerPrice(container) {
   const stickerContainer = findInContainer(itemContainer, 'sticker-container');
 
   if (!stickerContainer || !settings.enableStickers) return null;
-  
+
   const stickerRefs = [...stickerContainer.getElementsByTagName('img')].map(img =>
     img.getAttribute('aria-describedby')
   );
@@ -109,13 +109,13 @@ async function getItemStickerPrice(container) {
   for (let i = 0; i < stickerRefs.length; i++) {
     const stickerRef = stickerRefs[i];
     const stickerText = document.querySelector(`#${stickerRef}`).innerHTML;
-    if(!stickerText.includes('0%')) continue;
-    
+    if (!stickerText.includes('0%')) continue;
+
     const sticker = stickerText.match(/^.*(?=\s\d+%)/)
 
     const stickerPrice = await getBuffPrice(sticker);
 
-    if(typeof(stickerPrice) != "number") continue;
+    if (typeof (stickerPrice) != "number") continue;
 
     totalStickerPrice += stickerPrice;
   }
@@ -182,7 +182,7 @@ async function copyAndPasteItemName() {
       newPriceDiv.style.color = settings.lossColor;
       newPriceDiv.textContent = `$${price} (${discount}%)`;
     }
-    if(settings.enableStickers && stickerPrice) {
+    if (settings.enableStickers && stickerPrice) {
       const priceWithStickers = price + stickerPrice
       const differenceStickersPercentage = (actualPriceNumber / priceWithStickers) * 100;
       const discountSticker = Math.round(differenceStickersPercentage);
@@ -190,7 +190,7 @@ async function copyAndPasteItemName() {
       if (discountSticker < settings.stickerThreshold && discountSticker >= 0 || isNaN(discountSticker)) {
         newStickerDiv.style.color = settings.profitColor;
         newStickerDiv.textContent = `${discountSticker}% SV ($${priceWithStickers.toFixed(2)} CV)`;
-      }  else {
+      } else {
         newStickerDiv.style.color = settings.lossColor;
         newStickerDiv.textContent = `${discountSticker}% SV ($${priceWithStickers.toFixed(2)} CV)`;
       }
@@ -203,12 +203,12 @@ async function copyAndPasteItemName() {
   link.target = '_blank';
   link.innerHTML = '<mat-icon _ngcontent-ele-c200="" role="img" class="mat-icon notranslate material-icons mat-icon-no-color" aria-hidden="true" data-mat-icon-type="font">link</mat-icon>';
   link.style.marginLeft = '10px';
-  
+
 
   newPriceParentDiv.appendChild(newPriceDiv);
   newPriceParentDiv.appendChild(link);
   ngStarInsertedDiv.parentNode.insertBefore(newPriceParentDiv, ngStarInsertedDiv.nextSibling);
-  if(settings.enableStickers){
+  if (settings.enableStickers) {
     newStickerParentDiv.appendChild(newStickerDiv);
     newPriceParentDiv.parentNode.insertBefore(newStickerParentDiv, newPriceParentDiv.nextSibling);
   }
@@ -222,7 +222,7 @@ setInterval(() => {
   }
 }, 1000);
 
-chrome.storage.local.get(['enableStickers', 'stickerThreshold', 'profitColor', 'lossColor', 'neutralColor'], (response) => {
+chrome.runtime.sendMessage({ action: 'getSettings' }, function (response) {
   settings = {
     enableStickers: response.enableStickers || false,
     stickerThreshold: response.stickerThreshold || 50,

--- a/no-api-version/content.js
+++ b/no-api-version/content.js
@@ -185,7 +185,7 @@ async function copyAndPasteItemName() {
       const differenceStickersPercentage = (actualPriceNumber / priceWithStickers) * 100;
       const discountSticker = Math.round(differenceStickersPercentage);
 
-      if (discountSticker < 50 && discountSticker >= 0 || isNaN(discountSticker)) {
+      if (discountSticker < settings.stickerThreshold && discountSticker >= 0 || isNaN(discountSticker)) {
         newStickerDiv.style.color = settings.profitColor;
         newStickerDiv.textContent = `${discountSticker}% SV ($${priceWithStickers.toFixed(2)} CV)`;
       }  else {
@@ -220,9 +220,10 @@ setInterval(() => {
   }
 }, 1000);
 
-chrome.storage.local.get(['enableStickers', 'profitColor', 'lossColor', 'neutralColor'], (response) => {
+chrome.storage.local.get(['enableStickers', 'stickerThreshold', 'profitColor', 'lossColor', 'neutralColor'], (response) => {
   settings = {
     enableStickers: response.enableStickers || false,
+    stickerThreshold: response.stickerThreshold || 50,
     profitColor: response.profitColor || '#00FF00',
     lossColor: response.lossColor || '#FF0000',
     neutralColor: response.neutralColor || '#FFA500',

--- a/no-api-version/options.html
+++ b/no-api-version/options.html
@@ -15,6 +15,11 @@
 	</label>
 	<br>
 	<label>
+		Sticker Value % Profit Threshold:
+		<input type="number" min="1" max="100" id="stickerThreshold"> 
+	</label>
+	<br>
+	<label>
 		Profit color:
 		<input type="color" id="profitColor">
 	</label>

--- a/no-api-version/options.html
+++ b/no-api-version/options.html
@@ -8,9 +8,10 @@
 
 <body>
 	<h1>Extension Options</h1>
-	<h3>No need to save anything, it'll be automatically saved in the extension localStorage. F5 on CSFloat to see your changes</h3>
+	<h3>No need to save anything, it'll be automatically saved. Refresh (F5) on CSFloat to see your changes!</h3>
 	<label>
-		<input type="checkbox" id="enableStickers"> Enable Stickers Price Checker <strong>[Not available right now]</strong>
+		Enable Stickers Price Checker:
+		<input type="checkbox" id="enableStickers"> 
 	</label>
 	<br>
 	<label>

--- a/no-api-version/options.js
+++ b/no-api-version/options.js
@@ -1,38 +1,38 @@
-document.addEventListener('DOMContentLoaded', function () {
+document.addEventListener('DOMContentLoaded', () => {
 	const enableStickersOption = document.getElementById('enableStickers');
 	const profitColorOption = document.getElementById('profitColor');
 	const lossColorOption = document.getElementById('lossColor');
 	const neutralColorOption = document.getElementById('neutralColor');
 	const resetButton = document.getElementById('reset');
 
-	chrome.storage.local.get(['enableStickers', 'profitColor', 'lossColor', 'neutralColor'], function (result) {
+	chrome.storage.local.get(['enableStickers', 'profitColor', 'lossColor', 'neutralColor'], (result) => {
 		enableStickersOption.checked = result.enableStickers || false;
 		profitColorOption.value = result.profitColor || '#00FF00';
 		lossColorOption.value = result.lossColor || '#FF0000';
 		neutralColorOption.value = result.neutralColor || '#FFA500';
 	});
 
-	enableStickersOption.addEventListener('change', function () {
+	enableStickersOption.addEventListener('change', () => {
 		const enableStickers = enableStickersOption.checked;
 		chrome.storage.local.set({'enableStickers': enableStickers});
 	});
 
-	profitColorOption.addEventListener('change', function () {
+	profitColorOption.addEventListener('change', () => {
 		const profitColor = profitColorOption.value;
 		chrome.storage.local.set({ 'profitColor': profitColor });
 	});
 
-	lossColorOption.addEventListener('change', function () {
+	lossColorOption.addEventListener('change', () => {
 		const lossColor = lossColorOption.value;
 		chrome.storage.local.set({ 'lossColor': lossColor });
 	});
 
-	neutralColorOption.addEventListener('change', function () {
+	neutralColorOption.addEventListener('change', () => {
 		const neutralColor = neutralColorOption.value;
 		chrome.storage.local.set({ 'neutralColor': neutralColor });
 	});
 
-	resetButton.addEventListener('click', function () {
+	resetButton.addEventListener('click', () => {
 		chrome.storage.local.set({
 			enableStickers: false,
 			profitColor: '#00FF00',

--- a/no-api-version/options.js
+++ b/no-api-version/options.js
@@ -1,12 +1,14 @@
 document.addEventListener('DOMContentLoaded', () => {
 	const enableStickersOption = document.getElementById('enableStickers');
+	const stickerThresholdOption = document.getElementById('stickerThreshold');
 	const profitColorOption = document.getElementById('profitColor');
 	const lossColorOption = document.getElementById('lossColor');
 	const neutralColorOption = document.getElementById('neutralColor');
 	const resetButton = document.getElementById('reset');
 
-	chrome.storage.local.get(['enableStickers', 'profitColor', 'lossColor', 'neutralColor'], (result) => {
+	chrome.storage.local.get(['enableStickers', 'estickerThreshold', 'profitColor', 'lossColor', 'neutralColor'], (result) => {
 		enableStickersOption.checked = result.enableStickers || false;
+		stickerThresholdOption.value = result.estickerThreshold || 50;
 		profitColorOption.value = result.profitColor || '#00FF00';
 		lossColorOption.value = result.lossColor || '#FF0000';
 		neutralColorOption.value = result.neutralColor || '#FFA500';
@@ -15,6 +17,11 @@ document.addEventListener('DOMContentLoaded', () => {
 	enableStickersOption.addEventListener('change', () => {
 		const enableStickers = enableStickersOption.checked;
 		chrome.storage.local.set({'enableStickers': enableStickers});
+	});
+
+	stickerThresholdOption.addEventListener('change', () => {
+		const stickerThreshold = stickerThresholdOption.value;
+		chrome.storage.local.set({'stickerThreshold': stickerThreshold});
 	});
 
 	profitColorOption.addEventListener('change', () => {
@@ -35,11 +42,13 @@ document.addEventListener('DOMContentLoaded', () => {
 	resetButton.addEventListener('click', () => {
 		chrome.storage.local.set({
 			enableStickers: false,
+			stickerThreshold: 50,
 			profitColor: '#00FF00',
 			lossColor: '#FF0000',
 			neutralColor: '#FFA500'
 		});
 		enableStickersOption.checked = false;
+		stickerThresholdOption.value = 50;
 		profitColorOption.value = '#00FF00';
 		lossColorOption.value = '#FF0000';
 		neutralColorOption.value = '#FFA500';

--- a/no-api-version/options.js
+++ b/no-api-version/options.js
@@ -16,12 +16,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
 	enableStickersOption.addEventListener('change', () => {
 		const enableStickers = enableStickersOption.checked;
-		chrome.storage.local.set({'enableStickers': enableStickers});
+		chrome.storage.local.set({ 'enableStickers': enableStickers });
 	});
 
 	stickerThresholdOption.addEventListener('change', () => {
 		const stickerThreshold = stickerThresholdOption.value;
-		chrome.storage.local.set({'stickerThreshold': stickerThreshold});
+		chrome.storage.local.set({ 'stickerThreshold': stickerThreshold });
 	});
 
 	profitColorOption.addEventListener('change', () => {

--- a/no-api-version/options.js
+++ b/no-api-version/options.js
@@ -6,30 +6,30 @@ document.addEventListener('DOMContentLoaded', function () {
 	const resetButton = document.getElementById('reset');
 
 	chrome.storage.local.get(['enableStickers', 'profitColor', 'lossColor', 'neutralColor'], function (result) {
-		enableStickersOption.checked = result.enableFeature || false;
+		enableStickersOption.checked = result.enableStickers || false;
 		profitColorOption.value = result.profitColor || '#00FF00';
 		lossColorOption.value = result.lossColor || '#FF0000';
 		neutralColorOption.value = result.neutralColor || '#FFA500';
 	});
 
 	enableStickersOption.addEventListener('change', function () {
-		const enableFeature = checkboxOptionOption.checked;
-		chrome.storage.local.set({ enableFeature });
+		const enableStickers = enableStickersOption.checked;
+		chrome.storage.local.set({'enableStickers': enableStickers});
 	});
 
 	profitColorOption.addEventListener('change', function () {
 		const profitColor = profitColorOption.value;
-		chrome.storage.local.set({ profitColor });
+		chrome.storage.local.set({ 'profitColor': profitColor });
 	});
 
 	lossColorOption.addEventListener('change', function () {
 		const lossColor = lossColorOption.value;
-		chrome.storage.local.set({ lossColor });
+		chrome.storage.local.set({ 'lossColor': lossColor });
 	});
 
 	neutralColorOption.addEventListener('change', function () {
 		const neutralColor = neutralColorOption.value;
-		chrome.storage.local.set({ neutralColor });
+		chrome.storage.local.set({ 'neutralColor': neutralColor });
 	});
 
 	resetButton.addEventListener('click', function () {


### PR DESCRIPTION
Fixed sticker option not saving/loading.

Added feature to show the buff craft price sticker value % against the listed float sale price.

I normally think its base skin price + sticker prices. But some high tier traders might say skin prices doesn't matter depending on sticker value. If this is the case I can add it in another commit.

The price checker ignores scraped sticker values.

![image](https://github.com/bycop/csfloat-buff-checker/assets/142036562/6f99cbb4-ada0-4f78-b59f-866ea6980058)

![image](https://github.com/bycop/csfloat-buff-checker/assets/142036562/aa74bcaf-1e44-49eb-8644-eb0e04c41e12)
